### PR TITLE
feat: use vim std helper for better support for NVIM_APPNAME

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -131,7 +131,7 @@ end
 lazy.setup {
 
   dev = {
-    path = "~/.config/nvim/projects",
+    path = vim.fn.stdpath("config") .. "/" .. "projects",
     fallback = false,
   },
 


### PR DESCRIPTION
currently, the local plugin is hardcoded into the ~/.config/nvim directory, but generally speaking, if a neovim user tries a new configuration, people tend to use the NVIM_APPNAME environment variable so that they can use the new configuration without affecting their current one. 
The changes in this pull request modify the hardcoded location to dynamically obtain it using vim.fn.stdpath, making it easier for NVIM_APPNAME users to try out this configuration.